### PR TITLE
v0.9c - Air Canada site edition

### DIFF
--- a/ita-matrix-powertools.console.js
+++ b/ita-matrix-powertools.console.js
@@ -228,6 +228,9 @@ function printSettingsvalue(target){
       case "language":
           ret=mptUsersettings["language"];
           break;
+      case "acEdition":
+          ret=mptUsersettings["acEdition"];
+          break;
       default:
           ret=boolToEnabled(mptUsersettings[target]);
   }

--- a/ita-matrix-powertools.console.js
+++ b/ita-matrix-powertools.console.js
@@ -5,6 +5,8 @@
  Copyright Reserved -- At least share with credit if you do
 
 *********** Changelog **************
+**** Version 0.9c ****
+# 2013-03-17 Edited by dja852  (Added options to select Air Canada site edition)
 **** Version 0.9b ****
 # 2015-03-17 Edited by Steppo (Adapted to new classes)
 **** Version 0.9a ****
@@ -99,6 +101,9 @@ mptUsersettings["enableInlinemode"] =  0; // enables inline mode - valid: 0 / 1
 mptUsersettings["enableIMGautoload"] = 0; // enables images to auto load - valid: 0 / 1
 mptUsersettings["enableFarerules"] = 1; // enables fare rule opening in new window - valid: 0 / 1
 mptUsersettings["enablePricebreakdown"] =  1; // enables price breakdown - valid: 0 / 1
+mptUsersettings["acEdition"] = "us"; // sets the local edition of AirCanada.com for itinerary pricing - valid: "us", "ca", "ar", "au", "ch", "cl", "cn", "co", "de", "dk", "es", "fr", "gb", "hk", "ie", "il", "it", "jp", "mx", "nl", "no", "pa", "pe", "se"
+
+var acEditions = ["us", "ca", "ar", "au", "ch", "cl", "cn", "co", "de", "dk", "es", "fr", "gb", "hk", "ie", "il", "it", "jp", "mx", "nl", "no", "pa", "pe", "se"];
 
 // *** DO NOT CHANGE BELOW THIS LINE***/
 // General settings
@@ -161,13 +166,15 @@ function createUsersettings(){
     target.innerHTML +='<span id="mptenableInlinemode" style="cursor:pointer;">Inlinemode:<span>'+printSettingsvalue("enableInlinemode")+'</span></span><br>';
     target.innerHTML +='<span id="mptenableIMGautoload" style="cursor:pointer;">Images autoload:<span>'+printSettingsvalue("enableIMGautoload")+'</span></span><br>';
     target.innerHTML +='<span id="mptenableFarerules" style="cursor:pointer;">Farerules in new window:<span>'+printSettingsvalue("enableFarerules")+'</span></span><br>';
-    target.innerHTML +='<span id="mptenablePricebreakdown" style="cursor:pointer;">Price breakdown:<span>'+printSettingsvalue("enablePricebreakdown")+'</span></span>';
+    target.innerHTML +='<span id="mptenablePricebreakdown" style="cursor:pointer;">Price breakdown:<span>'+printSettingsvalue("enablePricebreakdown")+'</span></span><br>';
+    target.innerHTML +='<span id="mptacEdition" style="cursor:pointer;">Air Canada Edition:<span>'+printSettingsvalue("acEdition")+'</span></span>';
     document.getElementById('mpttimeformat').onclick=function(){toggleSettings("timeformat");};
     document.getElementById('mptlanguage').onclick=function(){toggleSettings("language");};
     document.getElementById('mptenableInlinemode').onclick=function(){toggleSettings("enableInlinemode");};
     document.getElementById('mptenableIMGautoload').onclick=function(){toggleSettings("enableIMGautoload");};
     document.getElementById('mptenableFarerules').onclick=function(){toggleSettings("enableFarerules");};
     document.getElementById('mptenablePricebreakdown').onclick=function(){toggleSettings("enablePricebreakdown");};
+    document.getElementById('mptacEdition').onclick=function(){toggleSettings("acEdition");};
 }
 function toggleSettingsvis(){
   var target=document.getElementById("mptSettings");
@@ -195,6 +202,13 @@ function toggleSettings(target){
            mptUsersettings["language"]="de";
          }
           break;
+      case "acEdition":
+      		if (acEditions.indexOf(mptUsersettings["acEdition"]) == (acEditions.length - 1)) {
+			mptUsersettings["acEdition"] = acEditions[0];
+      		} else {
+      			mptUsersettings["acEdition"] = acEditions[(acEditions.indexOf(mptUsersettings["acEdition"]) + 1)];	
+      		}
+      	break;
       default:
         if (mptUsersettings[target]==1){
            mptUsersettings[target]=0;
@@ -1044,7 +1058,7 @@ function printAC(data){
     if (mptSettings["itaLanguage"]=="de"||mptUsersettings["language"]=="de"){
     acUrl += '&country=DE&countryOfResidence=DE&language=de&LANGUAGE=DE';
     } else {
-    acUrl += '&country=US&countryOfResidence=US&language=en&LANGUAGE=US';
+    	acUrl += '&country=' + mptUsersettings["acEdition"].toUpperCase() + '&countryofResidence=' + mptUsersettings["acEdition"].toUpperCase() + '&language=en&LANGUAGE=US';
     }
   acUrl += '&CREATION_MODE=30&EMBEDDED_TRANSACTION=FareServelet&FareRequest=YES&fromThirdParty=YES&HAS_INFANT_1=False&IS_PRIMARY_TRAVELLER_1=True&SITE=SAADSAAD&thirdPartyID=0005118&TRAVELER_TYPE_1=ADT&PRICING_MODE=0';
   acUrl += '&numberOfChildren=0&numberOfInfants=0&numberOfYouth=0&numberOfAdults=' + data["numPax"];

--- a/ita-matrix-powertools.user.js
+++ b/ita-matrix-powertools.user.js
@@ -222,7 +222,7 @@ function toggleSettings(target){
          }
           break;
       case "acEdition":
-      	switch(mptUsersettings["acEdition"]){
+      	switch(mptUsersettings["acEdition"]) {
       		case "us":
       			mptUsersettings["acEdition"] = "ca";
       			break;

--- a/ita-matrix-powertools.user.js
+++ b/ita-matrix-powertools.user.js
@@ -2,7 +2,7 @@
 // @name DL/ORB Itinary Builder
 // @namespace https://github.com/SteppoFF/ita-matrix-powertools
 // @description Builds fare purchase links
-// @version 0.9b4
+// @version 0.9c
 // @grant GM_getValue
 // @grant GM_setValue
 // @include http*://matrix.itasoftware.com/*
@@ -15,6 +15,8 @@
  Copyright Reserved -- At least share with credit if you do
 
 *********** Changelog **************
+**** Version 0.9c ****
+# 2013-03-17 Edited by dja852 (Added options to select Air Canada site edition)
 **** Version 0.9b ****
 # 2015-03-17 Edited by Steppo (Adapted to new classes)
 **** Version 0.9a ****

--- a/ita-matrix-powertools.user.js
+++ b/ita-matrix-powertools.user.js
@@ -2,7 +2,7 @@
 // @name DL/ORB Itinary Builder
 // @namespace https://github.com/SteppoFF/ita-matrix-powertools
 // @description Builds fare purchase links
-// @version 0.9b2
+// @version 0.9b3
 // @grant GM_getValue
 // @grant GM_setValue
 // @include http*://matrix.itasoftware.com/*
@@ -115,6 +115,8 @@ mptUsersettings["enableFarerules"] = mptSavedUsersettings["enableFarerules"] || 
 mptUsersettings["enablePricebreakdown"] = mptSavedUsersettings["enablePricebreakdown"] || 1; // enables price breakdown - valid: 0 / 1
 mptUsersettings["acEdition"] = mptSavedUsersettings["acEdition"] || "us";
 
+var acEditions = ["us", "ca", "ar", "au", "hk"]
+
 // *** DO NOT CHANGE BELOW THIS LINE***/
 // General settings
 var mptSettings = new Object();
@@ -222,7 +224,7 @@ function toggleSettings(target){
          }
           break;
       case "acEdition":
-      	switch(mptUsersettings["acEdition"]) {
+      /*	switch(mptUsersettings["acEdition"]) {
       		case "us":
       			mptUsersettings["acEdition"] = "ca";
       			break;
@@ -232,7 +234,13 @@ function toggleSettings(target){
       		case "au":
       			mptUsersettings["acEdition"] = "us";
       			break;
-      	}
+      	} */
+      	
+      		if (acEditions.indexOf(mptUsersettings["acEdition"]) == (acEditions.length - 1)) {
+			mptUsersettings["acEdition"] = acEditions[0];
+      		} else {
+      			mptUsersettings["acEdition"] = acEditions[(acEditions.indexOf(mptUsersettings["acEdition"]) + 1)];	
+      		}
       	break;
       default:
         if (mptUsersettings[target]==1){

--- a/ita-matrix-powertools.user.js
+++ b/ita-matrix-powertools.user.js
@@ -2,7 +2,7 @@
 // @name DL/ORB Itinary Builder
 // @namespace https://github.com/SteppoFF/ita-matrix-powertools
 // @description Builds fare purchase links
-// @version 0.9b1
+// @version 0.9b2
 // @grant GM_getValue
 // @grant GM_setValue
 // @include http*://matrix.itasoftware.com/*
@@ -1087,18 +1087,7 @@ function printAC(data){
     if (mptSettings["itaLanguage"]=="de"||mptUsersettings["language"]=="de"){
     acUrl += '&country=DE&countryOfResidence=DE&language=de&LANGUAGE=DE';
     } else {
-    	switch(mptUsersettings["acEdition"]) {
-    		case "us":
-    			acUrl += '&country=US&countryOfResidence=US&language=en&LANGUAGE=US';
-    			break;
-    		case "ca":
-    			acUrl += '&country=CA&countryOfResidence=CA&language=en&LANGUAGE=US';
-    			break;
-    		case "au":
-    			acUrl += '&country=AU&countryOfResidence=AU&language=en&LANGUAGE=US';
-    			break;
-    			
-    	}
+    	acUrl += '&country=' + mptUsersettings["acEdition"].toUpperCase() + '&countryofResidence=' + mptUsersettings["acEdition"].toUpperCase() + '&language=en&LANGUAGE=US';
     }
   acUrl += '&CREATION_MODE=30&EMBEDDED_TRANSACTION=FareServelet&FareRequest=YES&fromThirdParty=YES&HAS_INFANT_1=False&IS_PRIMARY_TRAVELLER_1=True&SITE=SAADSAAD&thirdPartyID=0005118&TRAVELER_TYPE_1=ADT&PRICING_MODE=0';
   acUrl += '&numberOfChildren=0&numberOfInfants=0&numberOfYouth=0&numberOfAdults=' + data["numPax"];

--- a/ita-matrix-powertools.user.js
+++ b/ita-matrix-powertools.user.js
@@ -16,7 +16,7 @@
 
 *********** Changelog **************
 **** Version 0.9c ****
-# 2013-03-17 Edited by dja852 (Added options to select Air Canada site edition)
+# 2013-03-17 Edited by dja852  (Added options to select Air Canada site edition)
 **** Version 0.9b ****
 # 2015-03-17 Edited by Steppo (Adapted to new classes)
 **** Version 0.9a ****

--- a/ita-matrix-powertools.user.js
+++ b/ita-matrix-powertools.user.js
@@ -222,7 +222,7 @@ function toggleSettings(target){
          }
           break;
       case "acEdition":
-      	switch(mptUserSettings["acEdition"]){
+      	switch(mptUsersettings["acEdition"]){
       		case "us":
       			mptUsersettings["acEdition"] = "ca";
       			break;

--- a/ita-matrix-powertools.user.js
+++ b/ita-matrix-powertools.user.js
@@ -117,7 +117,7 @@ mptUsersettings["enableFarerules"] = mptSavedUsersettings["enableFarerules"] || 
 mptUsersettings["enablePricebreakdown"] = mptSavedUsersettings["enablePricebreakdown"] || 1; // enables price breakdown - valid: 0 / 1
 mptUsersettings["acEdition"] = mptSavedUsersettings["acEdition"] || "us"; // sets the local edition of AirCanada.com for itinerary pricing
 
-var acEditions = ["us", "ca", "ar", "au", "ch", "cl", "cn", "co", "de", "dk", "es", "fr", "gb", "hk", "ie", "il", "it", "jp", "mx", "nl", "no", "pa", "pe", "se"]
+var acEditions = ["us", "ca", "ar", "au", "ch", "cl", "cn", "co", "de", "dk", "es", "fr", "gb", "hk", "ie", "il", "it", "jp", "mx", "nl", "no", "pa", "pe", "se"];
 
 // *** DO NOT CHANGE BELOW THIS LINE***/
 // General settings

--- a/ita-matrix-powertools.user.js
+++ b/ita-matrix-powertools.user.js
@@ -113,7 +113,7 @@ mptUsersettings["enableInlinemode"] = mptSavedUsersettings["enableInlinemode"] |
 mptUsersettings["enableIMGautoload"] = mptSavedUsersettings["enableIMGautoload"] || 0; // enables images to auto load - valid: 0 / 1
 mptUsersettings["enableFarerules"] = mptSavedUsersettings["enableFarerules"] || 1; // enables fare rule opening in new window - valid: 0 / 1
 mptUsersettings["enablePricebreakdown"] = mptSavedUsersettings["enablePricebreakdown"] || 1; // enables price breakdown - valid: 0 / 1
-mptUsersettings["acEdition"] = mptSavedUsersettings["acEdition"] || "us"
+mptUsersettings["acEdition"] = mptSavedUsersettings["acEdition"] || "us";
 
 // *** DO NOT CHANGE BELOW THIS LINE***/
 // General settings
@@ -253,6 +253,9 @@ function printSettingsvalue(target){
           break;
       case "language":
           ret=mptUsersettings["language"];
+          break;
+      case "acEdition":
+          ret=mptUsersettings["acEdition"];
           break;
       default:
           ret=boolToEnabled(mptUsersettings[target]);

--- a/ita-matrix-powertools.user.js
+++ b/ita-matrix-powertools.user.js
@@ -2,7 +2,7 @@
 // @name DL/ORB Itinary Builder
 // @namespace https://github.com/SteppoFF/ita-matrix-powertools
 // @description Builds fare purchase links
-// @version 0.9b3
+// @version 0.9b4
 // @grant GM_getValue
 // @grant GM_setValue
 // @include http*://matrix.itasoftware.com/*
@@ -113,9 +113,9 @@ mptUsersettings["enableInlinemode"] = mptSavedUsersettings["enableInlinemode"] |
 mptUsersettings["enableIMGautoload"] = mptSavedUsersettings["enableIMGautoload"] || 0; // enables images to auto load - valid: 0 / 1
 mptUsersettings["enableFarerules"] = mptSavedUsersettings["enableFarerules"] || 1; // enables fare rule opening in new window - valid: 0 / 1
 mptUsersettings["enablePricebreakdown"] = mptSavedUsersettings["enablePricebreakdown"] || 1; // enables price breakdown - valid: 0 / 1
-mptUsersettings["acEdition"] = mptSavedUsersettings["acEdition"] || "us";
+mptUsersettings["acEdition"] = mptSavedUsersettings["acEdition"] || "us"; // sets the local edition of AirCanada.com for itinerary pricing
 
-var acEditions = ["us", "ca", "ar", "au", "hk"]
+var acEditions = ["us", "ca", "ar", "au", "ch", "cl", "cn", "co", "de", "dk", "es", "fr", "gb", "hk", "ie", "il", "it", "jp", "mx", "nl", "no", "pa", "pe", "se"]
 
 // *** DO NOT CHANGE BELOW THIS LINE***/
 // General settings
@@ -224,18 +224,6 @@ function toggleSettings(target){
          }
           break;
       case "acEdition":
-      /*	switch(mptUsersettings["acEdition"]) {
-      		case "us":
-      			mptUsersettings["acEdition"] = "ca";
-      			break;
-      		case "ca":
-      			mptUsersettings["acEdition"] = "au";
-      			break;
-      		case "au":
-      			mptUsersettings["acEdition"] = "us";
-      			break;
-      	} */
-      	
       		if (acEditions.indexOf(mptUsersettings["acEdition"]) == (acEditions.length - 1)) {
 			mptUsersettings["acEdition"] = acEditions[0];
       		} else {

--- a/ita-matrix-powertools.user.js
+++ b/ita-matrix-powertools.user.js
@@ -2,7 +2,7 @@
 // @name DL/ORB Itinary Builder
 // @namespace https://github.com/SteppoFF/ita-matrix-powertools
 // @description Builds fare purchase links
-// @version 0.9b
+// @version 0.9b1
 // @grant GM_getValue
 // @grant GM_setValue
 // @include http*://matrix.itasoftware.com/*
@@ -113,7 +113,7 @@ mptUsersettings["enableInlinemode"] = mptSavedUsersettings["enableInlinemode"] |
 mptUsersettings["enableIMGautoload"] = mptSavedUsersettings["enableIMGautoload"] || 0; // enables images to auto load - valid: 0 / 1
 mptUsersettings["enableFarerules"] = mptSavedUsersettings["enableFarerules"] || 1; // enables fare rule opening in new window - valid: 0 / 1
 mptUsersettings["enablePricebreakdown"] = mptSavedUsersettings["enablePricebreakdown"] || 1; // enables price breakdown - valid: 0 / 1
-
+mptUsersettings["acEdition"] = mptSavedUsersettings["acEdition"] || "us"
 
 // *** DO NOT CHANGE BELOW THIS LINE***/
 // General settings
@@ -184,13 +184,16 @@ function createUsersettings(){
     target.innerHTML +='<span id="mptenableInlinemode" style="cursor:pointer;">Inlinemode:<span>'+printSettingsvalue("enableInlinemode")+'</span></span><br>';
     target.innerHTML +='<span id="mptenableIMGautoload" style="cursor:pointer;">Images autoload:<span>'+printSettingsvalue("enableIMGautoload")+'</span></span><br>';
     target.innerHTML +='<span id="mptenableFarerules" style="cursor:pointer;">Farerules in new window:<span>'+printSettingsvalue("enableFarerules")+'</span></span><br>';
-    target.innerHTML +='<span id="mptenablePricebreakdown" style="cursor:pointer;">Price breakdown:<span>'+printSettingsvalue("enablePricebreakdown")+'</span></span>';
+    target.innerHTML +='<span id="mptenablePricebreakdown" style="cursor:pointer;">Price breakdown:<span>'+printSettingsvalue("enablePricebreakdown")+'</span></span><br>';
+    target.innerHTML +='<span id="mptacEdition" style="cursor:pointer;">Air Canada Edition:<span>'+printSettingsvalue("acEdition")+'</span></span>';
     document.getElementById('mpttimeformat').onclick=function(){toggleSettings("timeformat");};
     document.getElementById('mptlanguage').onclick=function(){toggleSettings("language");};
     document.getElementById('mptenableInlinemode').onclick=function(){toggleSettings("enableInlinemode");};
     document.getElementById('mptenableIMGautoload').onclick=function(){toggleSettings("enableIMGautoload");};
     document.getElementById('mptenableFarerules').onclick=function(){toggleSettings("enableFarerules");};
     document.getElementById('mptenablePricebreakdown').onclick=function(){toggleSettings("enablePricebreakdown");};
+    document.getElementById('mptacEdition').onclick=function(){toggleSettings("acEdition");};
+	
 }
 function toggleSettingsvis(){
   var target=document.getElementById("mptSettings");
@@ -218,6 +221,19 @@ function toggleSettings(target){
            mptUsersettings["language"]="de";
          }
           break;
+      case "acEdition":
+      	switch(mptUserSettings["acEdition"]){
+      		case "us":
+      			mptUsersettings["acEdition"] = "ca";
+      			break;
+      		case "ca":
+      			mptUsersettings["acEdition"] = "au";
+      			break;
+      		case "au":
+      			mptUsersettings["acEdition"] = "us";
+      			break;
+      	}
+      	break;
       default:
         if (mptUsersettings[target]==1){
            mptUsersettings[target]=0;
@@ -1068,7 +1084,18 @@ function printAC(data){
     if (mptSettings["itaLanguage"]=="de"||mptUsersettings["language"]=="de"){
     acUrl += '&country=DE&countryOfResidence=DE&language=de&LANGUAGE=DE';
     } else {
-    acUrl += '&country=US&countryOfResidence=US&language=en&LANGUAGE=US';
+    	switch(mptUsersettings["acEdition"]) {
+    		case "us":
+    			acUrl += '&country=US&countryOfResidence=US&language=en&LANGUAGE=US';
+    			break;
+    		case "ca":
+    			acUrl += '&country=CA&countryOfResidence=CA&language=en&LANGUAGE=US';
+    			break;
+    		case "au":
+    			acUrl += '&country=AU&countryOfResidence=AU&language=en&LANGUAGE=US';
+    			break;
+    			
+    	}
     }
   acUrl += '&CREATION_MODE=30&EMBEDDED_TRANSACTION=FareServelet&FareRequest=YES&fromThirdParty=YES&HAS_INFANT_1=False&IS_PRIMARY_TRAVELLER_1=True&SITE=SAADSAAD&thirdPartyID=0005118&TRAVELER_TYPE_1=ADT&PRICING_MODE=0';
   acUrl += '&numberOfChildren=0&numberOfInfants=0&numberOfYouth=0&numberOfAdults=' + data["numPax"];


### PR DESCRIPTION
Added an option for the user to select which "Air Canada.com Edition" is being used for the Air Canada site links which will allow for pricing and paying for itineraries in different currencies that AC supports - I.e. USD, CAD, AUD, GBP, HKD etc.

Updated the User and Console versions only. I'm not 100% sure how to update the minified version.