### PR TITLE
Fix WhereToCredit URL

### DIFF
--- a/ita-matrix-powertools.user.js
+++ b/ita-matrix-powertools.user.js
@@ -3549,7 +3549,7 @@ function openWheretocredit(link) {
   }
   
   var xhr = new XMLHttpRequest();
-  xhr.open('POST', 'http://www.wheretocredit.com/api/beta/calculate');
+  xhr.open('POST', '//www.wheretocredit.com/api/beta/calculate');
   xhr.setRequestHeader('Accept', 'application/json;charset=UTF-8');
   xhr.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');
   xhr.onreadystatechange = function() {


### PR DESCRIPTION
The WhereToCredit URL in the unminified version is still http:// which leads to Chrome blocking the call due to mixed-content.

Thanks btw for maintaing the tools 👍 