### PR TITLE
Support for AC Promo Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ You can also create a [Bookmarklet](https://support.mozilla.org/en-US/kb/bookmar
 ### Latest major changes ###
 
 ##### Version 0.32 #####
+2019-10-16 Edited by TechnoTourist (Air Canada promo code input)
+
+##### Version 0.32 #####
 2019-08-06 Edited by canadiancow (Pass fare basis to Air Canada)
 
 ##### Version 0.26 #####

--- a/ita-matrix-powertools.user.js
+++ b/ita-matrix-powertools.user.js
@@ -2,7 +2,7 @@
 // @name ITA-Matrix-Powertools
 // @namespace https://github.com/SteppoFF/ita-matrix-powertools
 // @description Adds new features and builds fare purchase links for ITA Matrix
-// @version 0.32
+// @version 0.33
 // @require https://greasemonkey.github.io/gm4-polyfill/gm4-polyfill.js
 // @grant GM.getValue
 // @grant GM_setValue
@@ -16,6 +16,8 @@
  Includes contriutions by 18sas
  Copyright Reserved -- At least share with credit if you do
 *********** Latest Changes **************
+**** Version 0.33 ****
+# 2019-10-16 Edited by TechnoTourist (Air Canada promo code input)
 **** Version 0.32 ****
 # 2019-08-06 Edited by canadiancow (Pass fare basis to Air Canada)
 **** Version 0.31 ****

--- a/ita-matrix-powertools.user.js
+++ b/ita-matrix-powertools.user.js
@@ -2069,6 +2069,44 @@ function printAAc1(){
     }
 }
 
+function addACPromo() {
+  window.addACPromo = function () {
+    var input = document.getElementById("ac-promo-input");
+    input.style.display = "inline";
+    input.addEventListener("change", (event) => {
+      var replacement = (event.target.value != '' ? ('&AUTHORIZATION_ID=' + event.target.value) : '');
+      var link = document.getElementById("ac-promo-link");
+      var match = link.href.match(/(&AUTHORIZATION_ID=.*)/g);
+      if (match == null) {
+        link.href += replacement;
+      } else {
+        link.href = link.href.replace(match, replacement);
+      }
+    });
+
+    var link = document.getElementById("ac-promo-link");
+    link.style.display = "inline";
+  };
+}
+
+function addACPromoControls(url) {
+  var script = document.createElement('script');
+  script.appendChild(document.createTextNode('(' + addACPromo + ')();'));
+  (document.body || document.head || document.documentElement).appendChild(script);
+
+  var label = "Open"
+  if (translations[mptUsersettings["language"]] !== undefined) {
+    if (translations[mptUsersettings["language"]]["open"] !== undefined) {
+      label = translations[mptUsersettings["language"]]["open"];
+    }
+  }
+
+  var extra = '<input type="input" id="ac-promo-input" size="8" style="display:none;margin:0 5px;"></input>';
+  extra += '<label style="font-size:' + Number(mptUsersettings["linkFontsize"]) + '%;">';
+  extra += '<a id="ac-promo-link" style="display:none" target="_blank" href="' + url + '">' + label + '</a></label>';
+  return extra;
+}
+
 function printAC(){
   var createUrl = function (edition) {
     var acUrl = 'https://book.aircanada.com/pl/AConline/en/RedirectionServlet?FareRequest=YES&PRICING_MODE=0&fromThirdParty=YES';
@@ -2100,7 +2138,10 @@ function printAC(){
   }
   var extra = ' <span class="pt-hover-container">[+]<span class="pt-hover-menu">';
   extra += acEditions.map(function (edition, i) { return '<a href="' + createUrl(edition.toUpperCase()) + '" target="_blank">' + edition +'</a>'; }).join('<br/>');
+  extra += '<br/><a href="javascript:addACPromo();">Add Promo Code</a>'
   extra += '</span></span>';
+  extra += addACPromoControls(acUrl);
+
   if (mptUsersettings["enableInlinemode"]==1){
     printUrlInline(acUrl,"Air Canada","",null,extra);
   } else {


### PR DESCRIPTION
Add text field for an Air Canada promo code to be entered.

Once you have selected your desired routing, click the **+** beside **Use Air Canada** and choose **Add Promo Code** on the popup. Move your mouse off the popup and you'll see a text entry field for the promo code. Enter your code and click **Open** to open a new window with the AC booking.