### PR TITLE
Migrated from `moment-timezone` to `date-fns-tz`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "release:opera": "shipit opera ./webext"
   },
   "dependencies": {
-    "moment-timezone": "^0.5.27"
+    "date-fns": "^2.9.0",
+    "date-fns-tz": "^1.0.10"
   },
   "husky": {
     "hooks": {
@@ -28,8 +29,6 @@
     "@types/webpack-env": "^1.15.0",
     "@wext/shipit": "github:adamhwang/wext-shipit",
     "husky": "^4.2.1",
-    "moment-locales-webpack-plugin": "^1.1.2",
-    "moment-timezone-data-webpack-plugin": "^1.1.0",
     "path": "^0.12.7",
     "prettier": "^1.19.1",
     "pretty-quick": "^2.0.1",

--- a/src/links/airlines/aaSabre.js
+++ b/src/links/airlines/aaSabre.js
@@ -2,6 +2,7 @@ import mptUserSettings, { registerSetting } from "../../settings/userSettings";
 import { printNotification } from "../../utils";
 import { validatePax, register } from "..";
 import { currentItin } from "../../parse/itin";
+import { zonedTimeToUtc } from "date-fns-tz";
 import apTimeZones from "../../json/timezones.json";
 
 const aaSabreEditions = [
@@ -22,14 +23,8 @@ function printAaSabre() {
      *
      * This function accepts the IATA code for a given airport and
      * retrieves the timezone from a static array of known airport data
-     * (sourced from https://openflights.org/data.html, reduced to
+     * (sourced from https://www.flightstats.com, reduced to
      * airports with IATA code, and converted to keyed json format).
-     * We use that timezone and Moment Timezone to account for DST if
-     * the future date and timezone fall in a known DST locale.
-     *
-     * Future TODO: The static airport data adds bloat and must be
-     * manually updated. Moment Timezone also adds bloat. Consider
-     * alternative implementations?
      *
      * @param y 4-digit year
      * @param m 2-digit month
@@ -50,11 +45,7 @@ function printAaSabre() {
       t +
       ":00";
 
-    // use Moment Timezone to adjust for (if needed) DST of airport:
-    // (data is filtered to only +2 years to reduce file size)
-    let moment = require("moment-timezone");
-    let adjustedStr = moment.tz(datetimeStr, apTimeZones[ap]).format();
-    return Date.parse(adjustedStr);
+    return zonedTimeToUtc(datetimeStr, apTimeZones[ap]).getTime();
   };
 
   // validate Passengers here: Max Paxcount = 7 (Infs not included) - >11 = Adult - InfSeat = Child

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,11 +4,6 @@ const path = require("path");
 
 const { replace, tokens } = require("./scripts/replaceTokens");
 
-// Moment Timezone (for AA Sabre):
-const MomentTimezoneDataPlugin = require("moment-timezone-data-webpack-plugin");
-const MomentLocalesPlugin = require("moment-locales-webpack-plugin");
-const currentYear = new Date().getFullYear();
-
 module.exports = {
   entry: "./src/index.js",
   output: {
@@ -30,15 +25,6 @@ module.exports = {
         res[token] = JSON.stringify(tokens[token]);
         return res;
       }, {})
-    ),
-    new MomentTimezoneDataPlugin({
-      startYear: currentYear,
-      endYear: currentYear + 2
-    }),
-    // Strip all Moment locales except “en”, “es-us” and “de”
-    // (“en” is built into Moment and can’t be removed)
-    new MomentLocalesPlugin({
-      localesToKeep: ["de"]
-    })
+    )
   ]
 };


### PR DESCRIPTION
`date-fns-tz` uses the new `Intl.DateTimeFormat` api for its timezone conversion which does not require the offset lookup list. It also supports tree shaking which, in total, reduces the over userscript about 100kb. Additionally, it will not require a rebuild each year

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat